### PR TITLE
Improved YAML front-matter vignette: handling

### DIFF
--- a/R/processData.R
+++ b/R/processData.R
@@ -228,8 +228,8 @@ DataPackageR <- function(arg = NULL,masterfile=NULL) {
   write_me_out = purrr::map(vignettes_to_process,function(x){
     title = "Default Vignette Title. Add yaml title: to your document"
     thisfile = read_file(x)
-    stripped_yaml = gsub("---.*---","",thisfile)
-    frontmatter = gsub("(---.*---).*","\\1",thisfile)
+    stripped_yaml = gsub("---\\s*\n.*\n---\\s*\n","", thisfile)
+    frontmatter = gsub("(---\\s*\n.*\n---\\s*\n).*","\\1", thisfile)
     con = textConnection(frontmatter)
     fm  = rmarkdown::yaml_front_matter(con)
     if(is.null(fm[["vignette"]])){
@@ -241,7 +241,11 @@ DataPackageR <- function(arg = NULL,masterfile=NULL) {
     }else{
       #otherwise leave it as is.
     }
-    write_me_out = paste0("---\n",yaml::as.yaml(fm),"---\n",stripped_yaml)
+
+    tmp = fm$vignette
+    tmp = gsub("  $", "", paste0("vignette: >\n  ", gsub("\\}\\s*", "\\}\n  ", tmp)))
+    fm$vignette = NULL
+    write_me_out = paste0("---\n", paste0(yaml::as.yaml(fm), tmp), "---\n\n", stripped_yaml)
     write_me_out
   })
   names(write_me_out)=vignettes_to_process


### PR DESCRIPTION
Suppose you have a vignette in which the vignette line in the YAML front matter is formatted like this:

```
vignette: >
  %\VignetteIndexEntry{My Vignette}
  %\VignetteEngine{knitr::rmarkdown}
  \usepackage[utf8]{inputenc}
```
 
When using `devtools::build_vignettes()` on the package, the vignette builds fine, and the appropriate files are found in inst/doc/.
 
When using `buildDataSetPackage(package)`, the relevant bit of the YAML header in the vignettes/vignette.Rmd changes to this:
 
```
vignette: '%\VignetteIndexEntry{My Vignette} %\VignetteEngine{knitr::rmarkdown}
  \usepackage[utf8]{inputenc}'
```
 
After that, `build_vignettes()` will no longer build this Rmd file. It seems to be related to how `yaml::as.yaml()` formats the vignette element of the front matter.

Additionally, the bit that parses the YAML front matter out can occasionally grab up through <--- comments that follow the front matter because of the `---`. I added white space and new line to the regex to perhaps better stop the greedy search at the appropriate place.